### PR TITLE
TF-7468 remove password from agent

### DIFF
--- a/CSharp/avayacloud-client-agent/ImplAgent.cs
+++ b/CSharp/avayacloud-client-agent/ImplAgent.cs
@@ -37,8 +37,6 @@ namespace AvayaCloudClient
             public string Firstname;
             [JsonProperty("lastName")]
             public string Lastname;
-            [JsonProperty("password")]
-            public string Password;
             [JsonProperty("avayaPassword")]
             public string AvayaPassword;
             [JsonProperty("loginId")]
@@ -58,14 +56,13 @@ namespace AvayaCloudClient
             [JsonProperty("supervisorId")]
             public long? supervisorId;
 
-            public Agent(string username, string firstname, string lastname, string password,
+            public Agent(string username, string firstname, string lastname,
                 string avayaPassword, string loginID, int clientID, int agentStationGroupID,
                 string securityCode, string startDate, string endDate, List<int> skillIds, long? supervisorId)
             {
                 Username = username;
                 Firstname = firstname;
                 Lastname = lastname;
-                Password = password;
                 AvayaPassword = avayaPassword;
                 LoginID = loginID;
                 ClientID = clientID;
@@ -131,13 +128,12 @@ namespace AvayaCloudClient
         /// Public API for creating an Agent
         /// </summary>
         /// <param name="agent_username">User name of the Agent.This has to be unique across the system</param>
-        /// <param name="agent_password">Password of the agent.Minimum 8 characters. Must contain at least one digit. Must contain at least one special character </param>
         /// <param name="firstName">First Name of the Agent</param>
         /// <param name="lastName">Last Name of the Agent</param>
         /// <param name="startDate">Start date from which the agent is to be activated in the system</param>
         /// <param name="endDate">End date till the Agent will be activated in the system</param>
         /// <returns>Created Agent object</returns>
-        public async Task<Agent> createAgent(string agent_username, string agent_password, string firstName,
+        public async Task<Agent> createAgent(string agent_username, string firstName,
           string lastName, string startDate, string endDate)
         {
             await session.login();
@@ -150,7 +146,7 @@ namespace AvayaCloudClient
             {
                 startDate = DateTime.Now.ToString("yyyy-MM-dd");
             }
-            await sendCreateAgentRequest(subAccountId, agent_username, agent_password,firstName, lastName, startDate, endDate, agentStationGroupId, agentLoginId, skillIds);
+            await sendCreateAgentRequest(subAccountId, agent_username,firstName, lastName, startDate, endDate, agentStationGroupId, agentLoginId, skillIds);
             Console.WriteLine("Waiting for Agent creation to complete");
             bool agentCreated = await waitForAgentCreation(agent_username);
             Console.WriteLine(agentCreated ? "Agent creation " + agent_username + " successfull" : "Agent creation failed");
@@ -189,13 +185,13 @@ namespace AvayaCloudClient
             List<int> skillIds = skills.Select(s => s.ID).ToList();
             return skillIds;
         }
-        private async Task sendCreateAgentRequest(int subAccountId, string agent_username, string agent_password, string firstName,
+        private async Task sendCreateAgentRequest(int subAccountId, string agent_username, string firstName,
           string lastName, string startDate, string endDate, int agentStationGroupId,
             string agentLoginId, List<int> skillIds)
         {
             string securityCode = generateSecurityCode(agentLoginId);
             string avayaPassword = generateAvayaPassword(agentLoginId);
-            Agent agent = new Agent(agent_username, firstName, lastName, agent_password, avayaPassword, agentLoginId, subAccountId,
+            Agent agent = new Agent(agent_username, firstName, lastName, avayaPassword, agentLoginId, subAccountId,
                 agentStationGroupId, securityCode, startDate, endDate, skillIds, 0);
             HttpResponseMessage httpResponseMessage = await Session.client.PostAsJsonAsync("/spokenAbc/jobs/agents", agent);
             var responseJson = await httpResponseMessage.Content.ReadAsStringAsync();

--- a/NodeJS/__integration__/AgentClientCrud.dev.it.ts
+++ b/NodeJS/__integration__/AgentClientCrud.dev.it.ts
@@ -43,10 +43,7 @@ describe('AgentClient', () => {
     'createAgent',
     async () => {
       const username = 'abcagent1' // randomString(10)  ddksgy3dnr
-      const result = await agentClient.createAgentAndStation(
-        username,
-        'Passw0rd!'
-      )
+      const result = await agentClient.createAgentAndStation(username)
       console.log(result)
       expect(result.agent.username).toEqual(username)
     },

--- a/NodeJS/__integration__/AgentClientCrud.integration.it.ts
+++ b/NodeJS/__integration__/AgentClientCrud.integration.it.ts
@@ -48,10 +48,7 @@ describe('AgentClient', () => {
       // const username = 'ddksgy3dnr' // randomString(10)
       const username = 'yangagent1' // randomString(10)
 
-      const result = await agentClient.createAgentAndStation(
-        username,
-        'Passw0rd!'
-      )
+      const result = await agentClient.createAgentAndStation(username)
       console.log(result)
       expect(result.agent.username).toEqual(username)
     },

--- a/NodeJS/__integration__/AgentClientCrud.it.ts
+++ b/NodeJS/__integration__/AgentClientCrud.it.ts
@@ -44,10 +44,7 @@ describe('AgentClient', () => {
     'createAgent',
     async () => {
       const username = 'ddksgy3dnr' // randomString(10)
-      const result = await agentClient.createAgentAndStation(
-        username,
-        'Passw0rd!'
-      )
+      const result = await agentClient.createAgentAndStation(username)
       console.log(result)
       expect(result.agent.username).toEqual(username)
     },

--- a/NodeJS/__unit__/AgentClient.test.ts
+++ b/NodeJS/__unit__/AgentClient.test.ts
@@ -9,15 +9,9 @@ describe('AgentClient.ts', () => {
     const restClient: any = RestClient as jest.Mock
     client = new AgentClient('1', 'MYA_MYARec', restClient)
   })
-  test('createAgentAndStation throws an error given an invalid password', async () => {
-    expect.assertions(1)
-    await expect(
-      client.createAgentAndStation('agent1', 'badpassword')
-    ).rejects.toEqual('invalid password')
-  })
   test('createAgentAndStation throws an error given an invalid username', async () => {
     expect.assertions(1)
-    expect(client.createAgentAndStation('a', 'Passw0rd@')).rejects.toEqual(
+    expect(client.createAgentAndStation('a')).rejects.toEqual(
       'invalid username'
     )
   })
@@ -27,9 +21,9 @@ describe('AgentClient.ts', () => {
     when(agentClientSpy.setDefaultSkillNumberIfNotExists()).thenResolve(false)
 
     expect.assertions(1)
-    expect(
-      client.createAgentAndStation('testuser', 'Passw0rd@')
-    ).rejects.toEqual('Can not create default skill for agent creation.')
+    expect(client.createAgentAndStation('testuser')).rejects.toEqual(
+      'Can not create default skill for agent creation.'
+    )
   })
 
   test('generateAvayaPassword should return last 6 characters', () => {

--- a/NodeJS/sample/SampleAgentClient.ts
+++ b/NodeJS/sample/SampleAgentClient.ts
@@ -8,52 +8,50 @@ const args = require('minimist')(process.argv.slice(2))
 let endpoint: string
 let apiKey: string
 let agentUsername: string
-let agentPassword: string
 try {
-    endpoint = getValue(Constants.ENDPOINT_KEY, args)
-    apiKey = getValue(Constants.API_KEY, args)
+  endpoint = getValue(Constants.ENDPOINT_KEY, args)
+  apiKey = getValue(Constants.API_KEY, args)
 
-    agentUsername = getValue(Constants.AGENT_USERNAME_KEY, args)
-    agentPassword = getValue(Constants.AGENT_PASSWORD_KEY, args)
+  agentUsername = getValue(Constants.AGENT_USERNAME_KEY, args)
 
-    main()
+  main()
 } catch (error) {
-    console.log(error)
-    process.exit(-1)
+  console.log(error)
+  process.exit(-1)
 }
 
 async function createAgent(agentClient: AgentClient) {
-    try {
-        const response = await agentClient.createAgentAndStation(agentUsername, agentPassword)
-        console.log(response)
-    } catch (e) {
-        console.error(e)
-    }
+  try {
+    const response = await agentClient.createAgentAndStation(agentUsername)
+    console.log(response)
+  } catch (e) {
+    console.error(e)
+  }
 }
 
 async function getAgent(agentClient: AgentClient) {
-    try {
-        const agentObject = await agentClient.getAgent(agentUsername)
-        console.log('agentObject from getAgent')
-        console.log(agentObject)
-    } catch (e) {
-        console.error(e)
-    }
+  try {
+    const agentObject = await agentClient.getAgent(agentUsername)
+    console.log('agentObject from getAgent')
+    console.log(agentObject)
+  } catch (e) {
+    console.error(e)
+  }
 }
 
 async function deleteAgent(agentClient: AgentClient) {
-    try {
-        await agentClient.deleteAgentAndStation(agentUsername)
-    } catch (e) {
-        console.error(e)
-    }
+  try {
+    await agentClient.deleteAgentAndStation(agentUsername)
+  } catch (e) {
+    console.error(e)
+  }
 }
 
 async function main() {
-    const agentClient = await createAgentClient(endpoint, apiKey)
-    await createAgent(agentClient)
-    await getAgent(agentClient)
-    await deleteAgent(agentClient)
-    const agentToken = await agentClient.getUserToken('yangadmin1')
-    console.log(agentToken)
+  const agentClient = await createAgentClient(endpoint, apiKey)
+  await createAgent(agentClient)
+  await getAgent(agentClient)
+  await deleteAgent(agentClient)
+  const agentToken = await agentClient.getUserToken('yangadmin1')
+  console.log(agentToken)
 }

--- a/NodeJS/src/AgentClient.ts
+++ b/NodeJS/src/AgentClient.ts
@@ -31,7 +31,6 @@ export class AgentClient {
   /**
    * Create Agent and Station. Upon success, returns agent object and station object
    * @param agentUsername min length 2, max length 20, must pass ^[-.@\w]+$
-   * @param agentPassword min length 8, max length 32, must have a uppercase character, must have at least one lowercase char, no whitespace, must contains a number, must contain one of ~!@?#$%^&*_
    */
   public async createAgentAndStation(agentUsername: string) {
     if (!isValidUsername(agentUsername)) {

--- a/NodeJS/src/AgentClient.ts
+++ b/NodeJS/src/AgentClient.ts
@@ -33,14 +33,7 @@ export class AgentClient {
    * @param agentUsername min length 2, max length 20, must pass ^[-.@\w]+$
    * @param agentPassword min length 8, max length 32, must have a uppercase character, must have at least one lowercase char, no whitespace, must contains a number, must contain one of ~!@?#$%^&*_
    */
-  public async createAgentAndStation(
-    agentUsername: string,
-    agentPassword: string
-  ) {
-    if (!isValidPassword(agentPassword)) {
-      return Promise.reject('invalid password')
-    }
-
+  public async createAgentAndStation(agentUsername: string) {
     if (!isValidUsername(agentUsername)) {
       return Promise.reject('invalid username')
     }
@@ -70,7 +63,6 @@ export class AgentClient {
 
     await this.createUserIfNotExists(
       agentUsername,
-      agentPassword,
       skillsWithPriority,
       agentStationGroupId
     )
@@ -119,7 +111,6 @@ export class AgentClient {
 
   public async createUserIfNotExists(
     agentUsername: string,
-    agentPassword: string,
     skillsWithPriority: SkillPriority[],
     agentStationGroupId: string
   ) {
@@ -139,7 +130,6 @@ export class AgentClient {
 
     await this.sendCreateAgentRequest(
       agentUsername,
-      agentPassword,
       agentStationGroupId,
       agentLoginId,
       skillsWithPriority
@@ -148,7 +138,6 @@ export class AgentClient {
   }
   public async sendCreateAgentRequest(
     agentUsername: string,
-    agentPassword: string,
     agentStationGroupId: any,
     agentLoginId: any,
     skillsWithPriority: SkillPriority[]
@@ -159,7 +148,6 @@ export class AgentClient {
       username: agentUsername,
       firstName: Constants.AGENT_FIRST_NAME,
       lastName: Constants.AGENT_LAST_NAME,
-      password: agentPassword,
       loginId: agentLoginId,
       agentStationGroupId,
       securityCode,


### PR DESCRIPTION
Whenever phone system user synchronization was built for Avaya OneCloud a password had to be generated by Tenfold for every agent created in Avaya's system. During early phases it made sense to store this password to help with development and troubleshooting, however, this password is now removed.