### PR TITLE
ENG-17239 NodeJS SDK:  Modify to allow up to 49 characters for usernames

### DIFF
--- a/NodeJS/__unit__/Utils.test.ts
+++ b/NodeJS/__unit__/Utils.test.ts
@@ -127,11 +127,15 @@ describe('Utils.ts', () => {
     expect(isValidUsername('john_smith')).toBeTruthy()
     expect(isValidUsername('john-smith')).toBeTruthy()
     expect(isValidUsername('john.smith')).toBeTruthy()
-    expect(isValidUsername('12345678901234567890')).toBeTruthy()
+    expect(
+      isValidUsername('1234567890123456789012345678901234567890123456789')
+    ).toBeTruthy()
   })
   test('isValidUsername should return false', () => {
     expect(isValidUsername('j')).toBeFalsy()
-    expect(isValidUsername('123456789012345678901')).toBeFalsy()
+    expect(
+      isValidUsername('12345678901234567890123456789012345678901234567890')
+    ).toBeFalsy()
   })
   test('isEmpty should return true', () => {
     expect(isEmpty('')).toBeTruthy()

--- a/NodeJS/package.json
+++ b/NodeJS/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avaya-cloud-api",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "client library for interacting with avaya cloud api",
   "main": "lib/src/index.js",
   "typings": "lib/src/index.d.ts",

--- a/NodeJS/src/Utils.ts
+++ b/NodeJS/src/Utils.ts
@@ -3,7 +3,8 @@ import { EMPTY_STRING, jwt, log4js, REPLACE_REGEX } from './Constants'
 import { SkillPriority } from './models'
 const logger = log4js.getLogger('Utils')
 const URL = require('url').URL
-const MAX_USERNAME_LENGTH = 20 // constraint from station username field
+// Username in mpact.user and ac_station.user is 50 chars long; Bulk upload uses 49, so does here.
+const MAX_USERNAME_LENGTH = 49
 
 export default function isValidParameter(key: string, parameter: any): boolean {
   if (parameter === undefined) {
@@ -107,7 +108,7 @@ export function hasAllowableCharacters(str: string) {
 }
 /**
  * check if a username is valid
- * @param username min length 2, max length 20, must pass ^[-.@\w]+$
+ * @param username min length 2, max length 49, must pass ^[-.@\w]+$
  */
 export function isValidUsername(username: string): boolean {
   if (username.length < 2 || username.length > MAX_USERNAME_LENGTH) {


### PR DESCRIPTION
update max username length to 49